### PR TITLE
feat: add svg icon default import to copy

### DIFF
--- a/.storybook/src/IconTooltip/IconTooltip.tsx
+++ b/.storybook/src/IconTooltip/IconTooltip.tsx
@@ -6,8 +6,8 @@ import './IconTooltip.scss';
 
 export interface IconTooltipProps {
     componentName: string;
-    svgPath: string;
-    importLine: string;
+    importSvg: string;
+    importComponent: string;
     children: React.ReactElement;
     forceOpen?: boolean;
 }
@@ -16,8 +16,8 @@ const b = block('icon-tooltip');
 
 export function IconTooltip({
     componentName,
-    svgPath,
-    importLine,
+    importSvg,
+    importComponent,
     forceOpen,
     children,
 }: IconTooltipProps) {
@@ -31,16 +31,16 @@ export function IconTooltip({
                         {componentName}
                     </Label>
                 </div>
-                <div className={b('label')}>Path</div>
+                <div className={b('label')}>Svg</div>
                 <div className={b('value')}>
-                    <Label type="copy" copyText={svgPath}>
-                        {svgPath}
+                    <Label type="copy" copyText={importSvg}>
+                        {importSvg}
                     </Label>
                 </div>
-                <div className={b('label')}>Import</div>
+                <div className={b('label')}>Component</div>
                 <div className={b('value')}>
-                    <Label type="copy" copyText={importLine}>
-                        {importLine}
+                    <Label type="copy" copyText={importComponent}>
+                        {importComponent}
                     </Label>
                 </div>
             </div>

--- a/.storybook/src/Showcase.stories.tsx
+++ b/.storybook/src/Showcase.stories.tsx
@@ -74,8 +74,8 @@ export const Showcase: Story = () => {
                         <IconTooltip
                             key={meta.svgName}
                             componentName={meta.componentName}
-                            svgPath={buildIconSvgPath(meta.svgName)}
-                            importLine={buildIconImportLine(meta.componentName)}
+                            importSvg={buildIconSvgPath(meta.svgName, meta.componentName)}
+                            importComponent={buildIconImportLine(meta.componentName)}
                             forceOpen={filteredItems.length === 1}
                         >
                             <Button view="flat" size="xl">
@@ -92,8 +92,8 @@ export const Showcase: Story = () => {
 };
 Showcase.storyName = 'Showcase';
 
-function buildIconSvgPath(svgName: string) {
-    return `@gravity-ui/icons/svgs/${svgName}.svg`;
+function buildIconSvgPath(svgName: string, componentName: string) {
+    return `import ${componentName}Icon '@gravity-ui/icons/svgs/${svgName}.svg';`;
 }
 
 function buildIconImportLine(componentName: string) {


### PR DESCRIPTION
Hi! in this awesome project, I lack the ability to copy the default import  of icon. I think it will be useful to many devs, let's add this feature

<img width="587" alt="Picture 2023-05-26 at 14 19 00" src="https://github.com/gravity-ui/icons/assets/27916444/f3420fc0-7371-450a-8ec1-9b65db0ea040">
